### PR TITLE
feat(api): conversation messages with agent router, bot info

### DIFF
--- a/DEV-README.md
+++ b/DEV-README.md
@@ -179,16 +179,16 @@ The rest of the architecture is in place so that the `analyze` command and pipel
 
 ### Backend
 
-Xem [backend/README.md](backend/README.md) để chạy backend đúng cách.
+See [backend/README.md](backend/README.md) for how to run the backend.
 
-**Tóm tắt:**
+**Summary:**
 1. `cd backend && pip install -r requirements.txt`
-2. Thêm `GEMINI_API_KEY` vào `.env` ở workspace root
-3. `cd backend && python3 run.py` – server tại `http://localhost:5000`
+2. Add `GEMINI_API_KEY` to `.env` in the workspace root
+3. `cd backend && python3 run.py` – server at `http://localhost:5000`
 
-**Lưu ý:** Chạy từ thư mục `backend/` hoặc dùng `python3 backend/run.py` từ root.
+**Note:** Run from the `backend/` directory or use `python3 backend/run.py` from the root.
 
 ### Frontend
 
 1. `cd frontend && npm install`
-2. `npm run dev` – chạy tại `http://localhost:3000` (proxy API sang backend)
+2. `npm run dev` – runs at `http://localhost:3000` (proxies API to backend)

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,89 +1,89 @@
 # BAWS Backend (Flask)
 
-Flask API cho BAWS - quản lý projects, documents và chạy analysis với Gemini agents.
+Flask API for BAWS – manages projects, documents, and runs analysis with Gemini agents.
 
-## Yêu cầu
+## Requirements
 
 - Python 3.10+
 - pip
 
-## Cài đặt
+## Setup
 
-1. **Tạo môi trường ảo (khuyến nghị):**
+1. **Create virtual environment (recommended):**
    ```bash
    cd backend
    python3 -m venv .venv
    source .venv/bin/activate   # Linux/macOS
-   # hoặc: .venv\Scripts\activate   # Windows
+   # or: .venv\Scripts\activate   # Windows
    ```
 
-2. **Cài dependencies:**
+2. **Install dependencies:**
    ```bash
    pip install -r requirements.txt
    ```
 
-3. **Cấu hình:**
-   - Copy `../.env.example` thành `../.env` ở thư mục workspace root
-   - Thêm `GEMINI_API_KEY` vào `.env`
-   - Copy `../_config/config.yaml.example` thành `../_config/config.yaml` (tự động nếu chưa có)
+3. **Configuration:**
+   - Copy `../.env.example` to `../.env` in the workspace root
+   - Add `GEMINI_API_KEY` to `.env`
+   - Copy `../_config/config.yaml.example` to `../_config/config.yaml` (done automatically if missing)
 
-## Chạy backend
+## Run the backend
 
-**Cách 1 (khuyến nghị) – chạy từ thư mục backend:**
+**Option 1 (recommended) – from backend directory:**
 ```bash
 cd backend
 python3 run.py
 ```
 
-**Cách 2 – chạy từ workspace root:**
+**Option 2 – from workspace root:**
 ```bash
 python3 backend/run.py
 ```
 
-Server mặc định chạy tại: **http://localhost:5000**
+Server runs at: **http://localhost:5000**
 
-**Swagger UI (Flasgger):** Mở **http://localhost:5000/apidocs** để xem và gọi thử API.
+**Swagger UI (Flasgger):** Open **http://localhost:5000/apidocs** to explore and try the API.
 
-### Biến môi trường
+### Environment variables
 
-| Biến | Mặc định | Mô tả |
-|------|----------|-------|
-| `PORT` | 5000 | Port chạy server |
-| `FLASK_RELOAD` | 0 | Bật reloader khi sửa code (1/true/yes). Tắt mặc định để tránh lỗi reloader |
-| `GEMINI_API_KEY` | - | API key Gemini (lấy tại https://aistudio.google.com/app/apikey) |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | 5000 | Server port |
+| `FLASK_RELOAD` | 0 | Enable reloader when editing code (1/true/yes). Off by default to avoid reloader issues |
+| `GEMINI_API_KEY` | - | Gemini API key (get at https://aistudio.google.com/app/apikey) |
 
-### Ví dụ
+### Examples
 
 ```bash
-# Port 5050
+# Custom port
 PORT=5050 python3 run.py
 
-# Bật reloader khi dev (chỉ dùng khi chạy từ thư mục backend/)
+# Enable reloader for development (run from backend directory)
 cd backend && FLASK_RELOAD=1 python3 run.py
 ```
 
 ## API Endpoints
 
-| Method | Endpoint | Mô tả |
-|--------|----------|-------|
+| Method | Endpoint | Description |
+|--------|----------|-------------|
 | GET | `/api/v1/health` | Health check |
-| GET | `/api/v1/projects` | Danh sách projects |
-| POST | `/api/v1/projects` | Tạo project |
-| GET | `/api/v1/projects/:id` | Chi tiết project |
-| PUT | `/api/v1/projects/:id` | Cập nhật project |
-| DELETE | `/api/v1/projects/:id` | Xóa project |
-| GET | `/api/v1/projects/:id/conversations` | Danh sách conversations |
-| POST | `/api/v1/projects/:id/conversations` | Tạo conversation (body: `{"title": "..."}`) |
-| GET | `/api/v1/projects/:id/conversations/:cid` | Chi tiết conversation |
-| PUT | `/api/v1/projects/:id/conversations/:cid` | Cập nhật conversation |
-| DELETE | `/api/v1/projects/:id/conversations/:cid` | Xóa conversation |
-| GET | `/api/v1/projects/:id/conversations/:cid/messages` | Danh sách messages |
-| POST | `/api/v1/projects/:id/conversations/:cid/messages` | Thêm message (body: `{"role":"user","content":"..."}`). Khi role=user, Agent BA tự động trả lời; response có thêm `assistant_message`. |
+| GET | `/api/v1/projects` | List projects |
+| POST | `/api/v1/projects` | Create project |
+| GET | `/api/v1/projects/:id` | Get project |
+| PUT | `/api/v1/projects/:id` | Update project |
+| DELETE | `/api/v1/projects/:id` | Delete project |
+| GET | `/api/v1/projects/:id/conversations` | List conversations |
+| POST | `/api/v1/projects/:id/conversations` | Create conversation (body: `{"title": "..."}`) |
+| GET | `/api/v1/projects/:id/conversations/:cid` | Get conversation |
+| PUT | `/api/v1/projects/:id/conversations/:cid` | Update conversation |
+| DELETE | `/api/v1/projects/:id/conversations/:cid` | Delete conversation |
+| GET | `/api/v1/projects/:id/conversations/:cid/messages` | List messages |
+| POST | `/api/v1/projects/:id/conversations/:cid/messages` | Add message. `content` can be a string or `{ "content_type": "text", "parts": ["..."] }`. When role=user, the BA agent replies; response includes `assistant_message` and `bot`. |
 | POST | `/api/v1/projects/:id/documents` | Upload document (form: file, optional conversation_id) |
-| GET | `/api/v1/projects/:id/documents` | Danh sách documents |
-| DELETE | `/api/v1/projects/:id/documents/:doc_id` | Xóa document |
-| POST | `/api/v1/projects/:id/analyze` | Chạy analysis (body: `{"document_id": 1, "conversation_id": 1}`) |
-| GET | `/api/v1/analyses/:id` | Lấy kết quả analysis |
+| GET | `/api/v1/projects/:id/documents` | List documents |
+| DELETE | `/api/v1/projects/:id/documents/:doc_id` | Delete document |
+| POST | `/api/v1/projects/:id/analyze` | Run analysis (body: `{"document_id": 1, "conversation_id": 1}`) |
+| GET | `/api/v1/analyses/:id` | Get analysis result |
 
 ## Data
 
@@ -91,4 +91,29 @@ cd backend && FLASK_RELOAD=1 python3 run.py
 - **Documents:** `data/documents/{project_id}/`
 - **Analysis output:** `data/output/analysis/{project_id}/`
 
-Tất cả nằm trong thư mục workspace, dễ backup và xóa.
+All under the workspace directory for easy backup and cleanup.
+
+## Message content format (POST messages)
+
+**Accepted `content`:**
+
+1. **Plain string** (legacy): `"content": "your message"`
+
+2. **Structured (GPT-style):**
+   ```json
+   "content": {
+     "content_type": "text",
+     "parts": [
+       "First segment (e.g. a short message or paragraph).",
+       "Second segment."
+     ]
+   }
+   ```
+
+**Rules for `parts`:**
+- Each item is a string (logical segment: paragraph, bullet, or sentence).
+- Backend trims each part and drops empty entries.
+- Parts are joined with `\n\n` so the prompt has clear structure for the router and Gemini.
+- Max 50 parts; total length capped for safety.
+
+Stored and sent to the model: a single normalized text (the joined string). Responses (e.g. GET messages) still return `content` as that stored string.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -56,8 +56,9 @@ def create_app(config=None):
     db.init_app(app)
     with app.app_context():
         db.create_all()
-        from app.db_migrate import migrate_add_conversation_columns
+        from app.db_migrate import migrate_add_conversation_columns, migrate_add_message_agent_id
 
         migrate_add_conversation_columns(app)
+        migrate_add_message_agent_id(app)
 
     return app

--- a/backend/app/agents/base.py
+++ b/backend/app/agents/base.py
@@ -27,6 +27,20 @@ def load_agent_yaml(agent_name: str) -> dict:
         return yaml.safe_load(f)
 
 
+def get_agent_bot_info(agent_name: str) -> dict:
+    """
+    Return bot info for API: { name, avatar, role }.
+    avatar is taken from metadata.icon in agent YAML.
+    """
+    data = load_agent_yaml(agent_name)
+    meta = data.get("agent", {}).get("metadata", {})
+    return {
+        "name": meta.get("name", agent_name.title()),
+        "avatar": meta.get("icon", ""),
+        "role": "assistant",
+    }
+
+
 def build_system_prompt(agent_name: str) -> str:
     """Build system prompt from agent YAML persona."""
     data = load_agent_yaml(agent_name)

--- a/backend/app/db_migrate.py
+++ b/backend/app/db_migrate.py
@@ -16,3 +16,16 @@ def migrate_add_conversation_columns(app):
                     db.session.commit()
                 except Exception:
                     db.session.rollback()
+
+
+def migrate_add_message_agent_id(app):
+    """Add agent_id to messages if missing (for existing DBs)."""
+    with app.app_context():
+        try:
+            db.session.execute(text("SELECT agent_id FROM messages LIMIT 1"))
+        except Exception:
+            try:
+                db.session.execute(text("ALTER TABLE messages ADD COLUMN agent_id VARCHAR(32)"))
+                db.session.commit()
+            except Exception:
+                db.session.rollback()

--- a/backend/app/models/message.py
+++ b/backend/app/models/message.py
@@ -14,6 +14,7 @@ class Message(db.Model):
     role = db.Column(db.String(32), nullable=False)  # user, assistant, system
     content = db.Column(db.Text, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    agent_id = db.Column(db.String(32), nullable=True)  # for assistant: which bot replied (paul, emma, sarah, david, alex)
 
     conversation = db.relationship("Conversation", back_populates="messages")
 
@@ -24,4 +25,5 @@ class Message(db.Model):
             "role": self.role,
             "content": self.content,
             "created_at": self.created_at.isoformat() if self.created_at else None,
+            "agent_id": self.agent_id,
         }

--- a/backend/app/services/agent_router.py
+++ b/backend/app/services/agent_router.py
@@ -1,0 +1,90 @@
+"""
+Router: infers which agent(s) should handle the user's question or input.
+Reads conversation-agents.yaml and uses the LLM to select one or more agents.
+"""
+import json
+import re
+from pathlib import Path
+
+from app.services.gemini_client import get_model
+
+WORKSPACE_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+CONVERSATION_AGENTS_CONFIG = (
+    WORKSPACE_ROOT / "src" / "modules" / "ba-analysis" / "config" / "conversation-agents.yaml"
+)
+
+_agents_config_cache = None
+
+
+def load_agents_config() -> list[dict]:
+    """Load and parse conversation-agents.yaml; return list of agent dicts."""
+    global _agents_config_cache
+    if _agents_config_cache is not None:
+        return _agents_config_cache
+    if not CONVERSATION_AGENTS_CONFIG.exists():
+        _agents_config_cache = []
+        return _agents_config_cache
+    import yaml
+    with open(CONVERSATION_AGENTS_CONFIG, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    _agents_config_cache = data.get("agents") or []
+    return _agents_config_cache
+
+
+def _build_router_prompt(agents: list[dict], user_message: str) -> str:
+    """Build prompt for LLM to select which agent(s) handle the message."""
+    lines = [
+        "You are a router. Given the following agents and the user message, choose which agent(s) should handle this request.",
+        "Reply with ONLY a JSON array of agent ids, e.g. [\"emma\"] or [\"emma\", \"sarah\"]. No other text.",
+        "",
+        "Agents:",
+    ]
+    for a in agents:
+        lines.append(f"  - id: {a.get('id', '')}")
+        lines.append(f"    responsibility: {a.get('responsibility', '')}")
+        lines.append(f"    description: {a.get('description', '').strip()[:200]}")
+        lines.append("")
+    lines.append("User message:")
+    lines.append(user_message[:2000])
+    lines.append("")
+    lines.append("Reply with JSON array of ids only:")
+    return "\n".join(lines)
+
+
+def route_to_agents(user_message: str) -> list[str]:
+    """
+    Infer which agent(s) should handle the user message.
+    Returns list of agent ids (e.g. ["emma", "sarah"]). Uses config conversation-agents.yaml.
+    """
+    agents = load_agents_config()
+    if not agents:
+        return ["alex"]
+    prompt = _build_router_prompt(agents, user_message or "")
+    model = get_model()
+    response = model.generate_content(prompt)
+    text = (response.text or "").strip()
+    # Parse JSON array from response (allow trailing text)
+    match = re.search(r"\[[\s\S]*?\]", text)
+    if not match:
+        return [agents[0]["id"]]
+    try:
+        ids = json.loads(match.group())
+        if not isinstance(ids, list):
+            return [agents[0]["id"]]
+        valid_ids = {a["id"] for a in agents}
+        selected = [x for x in ids if isinstance(x, str) and x in valid_ids]
+        return selected if selected else [agents[0]["id"]]
+    except (json.JSONDecodeError, TypeError):
+        return [agents[0]["id"]]
+
+
+def get_agent_info_from_config(agent_id: str) -> dict | None:
+    """Return { name, avatar, role } for an agent id from conversation-agents config."""
+    for a in load_agents_config():
+        if a.get("id") == agent_id:
+            return {
+                "name": a.get("name", agent_id.title()),
+                "avatar": a.get("avatar", ""),
+                "role": "assistant",
+            }
+    return None

--- a/backend/app/services/content_normalizer.py
+++ b/backend/app/services/content_normalizer.py
@@ -1,0 +1,58 @@
+"""
+Normalize user message content for prompts and storage.
+
+Accepts:
+- Plain string: "a single message"
+- Structured (GPT-style): { "content_type": "text", "parts": ["part one", "part two"] }
+
+Parts are logical segments (e.g. paragraphs, bullets, sentences). We trim each part,
+drop empty ones, and join with double newline so the prompt has clear structure for Gemini.
+"""
+
+# Maximum number of parts to avoid abuse
+MAX_PARTS = 50
+# Maximum total length after normalization (chars)
+MAX_NORMALIZED_LENGTH = 50_000
+
+
+def normalize_user_content(content) -> str:
+    """
+    Normalize content from API into a single string for DB storage and prompt.
+
+    - If content is str: return stripped string.
+    - If content is dict: expect content_type "text" and parts (list of strings).
+      Parts are trimmed, empty parts removed, joined with "\\n\\n".
+    - Invalid format raises ValueError (caller returns 400).
+    """
+    if content is None:
+        raise ValueError("content is required")
+
+    if isinstance(content, str):
+        out = content.strip()
+        if len(out) > MAX_NORMALIZED_LENGTH:
+            out = out[:MAX_NORMALIZED_LENGTH]
+        return out
+
+    if isinstance(content, dict):
+        if content.get("content_type") != "text":
+            raise ValueError(
+                "content.content_type must be \"text\". Other types may be supported later."
+            )
+        raw_parts = content.get("parts")
+        if not isinstance(raw_parts, list):
+            raise ValueError("content.parts must be an array of strings")
+        if len(raw_parts) > MAX_PARTS:
+            raise ValueError(f"content.parts must have at most {MAX_PARTS} items")
+        parts = []
+        for i, p in enumerate(raw_parts):
+            if not isinstance(p, str):
+                raise ValueError(f"content.parts[{i}] must be a string")
+            trimmed = p.strip()
+            if trimmed:
+                parts.append(trimmed)
+        out = "\n\n".join(parts)
+        if len(out) > MAX_NORMALIZED_LENGTH:
+            out = out[:MAX_NORMALIZED_LENGTH]
+        return out
+
+    raise ValueError("content must be a string or an object { content_type, parts }")

--- a/backend/app/services/conversation_agent.py
+++ b/backend/app/services/conversation_agent.py
@@ -1,11 +1,18 @@
-"""Conversation agent: BA chat with history (answer + follow-up questions toward BA docs)."""
+"""Conversation agent: BA chat with history; router selects agent(s), multiple agents may collaborate."""
 from pathlib import Path
 
+from app.agents.base import get_agent_bot_info
 from app.models import Message
+from app.services.agent_router import (
+    get_agent_info_from_config,
+    load_agents_config,
+    route_to_agents,
+)
 from app.services.gemini_client import generate_chat
 
+# Fallback when config has no agents or router returns none
+CONVERSATION_AGENT_ID = "alex"
 
-# Prompt file next to module prompts (workspace root = backend's parent's parent's parent)
 WORKSPACE_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 BA_CONVERSATION_PROMPT_PATH = (
     WORKSPACE_ROOT / "src" / "modules" / "ba-analysis" / "prompts" / "ba_conversation.prompt.txt"
@@ -16,7 +23,6 @@ def get_conversation_system_prompt() -> str:
     """Load BA conversation system prompt from module prompts."""
     if BA_CONVERSATION_PROMPT_PATH.exists():
         return BA_CONVERSATION_PROMPT_PATH.read_text(encoding="utf-8").strip()
-    # Fallback if file not found (e.g. running from different cwd)
     return (
         "You are a Senior Business Analyst. Answer the user's questions clearly. "
         "When information is missing, ask concise follow-up questions to clarify. "
@@ -24,23 +30,55 @@ def get_conversation_system_prompt() -> str:
     )
 
 
-def get_agent_reply(conversation_id: int, new_user_content: str) -> str:
+def _build_multi_agent_system_prompt(selected_agents: list[dict]) -> str:
+    """Build system prompt when multiple agents are selected (collaboration)."""
+    base = get_conversation_system_prompt()
+    parts = [
+        base,
+        "",
+        "You are responding as the following agent(s). Coordinate your answer from these perspectives:",
+    ]
+    for a in selected_agents:
+        parts.append(f"- {a.get('name', '')} ({a.get('responsibility', '')}): {a.get('description', '').strip()}")
+    parts.append("")
+    parts.append("Give one coherent reply that combines these viewpoints when relevant.")
+    return "\n".join(parts)
+
+
+def get_conversation_bot(primary_agent_id: str | None = None) -> dict:
     """
-    Get assistant reply for a conversation turn.
-    Loads message history for the conversation (user + assistant only), sends history
-    and new_user_content to Gemini chat, returns the model reply.
-    Does not persist anything; caller saves the assistant message if needed.
+    Return bot info { name, avatar, role }.
+    If primary_agent_id is in conversation-agents config, use it; else fallback to get_agent_bot_info (alex).
     """
+    if primary_agent_id:
+        info = get_agent_info_from_config(primary_agent_id)
+        if info:
+            return info
+    return get_agent_bot_info(CONVERSATION_AGENT_ID)
+
+
+def get_agent_reply(conversation_id: int, new_user_content: str) -> tuple[str, list[str]]:
+    """
+    Infer which agent(s) to use, build combined prompt when multiple agents, then reply.
+    Returns (reply_text, selected_agent_ids). Caller may use selected_agent_ids[0] for bot.
+    """
+    selected_ids = route_to_agents(new_user_content)
+    agents_config = load_agents_config()
+    selected_agents = [a for a in agents_config if a.get("id") in selected_ids]
+    if selected_agents:
+        system_prompt = _build_multi_agent_system_prompt(selected_agents)
+    else:
+        system_prompt = get_conversation_system_prompt()
+
     messages = (
         Message.query.filter_by(conversation_id=conversation_id)
         .order_by(Message.created_at.asc())
         .all()
     )
-    # Only user and assistant for chat history (no system in Gemini history)
     history = [
         {"role": m.role, "content": m.content or ""}
         for m in messages
         if m.role in ("user", "assistant")
     ]
-    system_prompt = get_conversation_system_prompt()
-    return generate_chat(system_prompt, history, new_user_content)
+    reply_text = generate_chat(system_prompt, history, new_user_content)
+    return reply_text, selected_ids

--- a/src/modules/ba-analysis/config/README.md
+++ b/src/modules/ba-analysis/config/README.md
@@ -1,0 +1,5 @@
+# Config – Conversation agents
+
+- **conversation-agents.yaml**: Declares 4 agents (Paul, Emma, Sarah, David) with responsibility and keywords.
+- The backend uses this file to **infer** which agent(s) handle each user question or input; **multiple agents** may be selected to collaborate.
+- Router: `backend/app/services/agent_router.py` (loads config and uses LLM to select agent ids).

--- a/src/modules/ba-analysis/config/conversation-agents.yaml
+++ b/src/modules/ba-analysis/config/conversation-agents.yaml
@@ -1,0 +1,76 @@
+# Config for 4 conversation agents – used to infer which agent(s) handle user questions or input.
+# The system may select one or multiple agents to collaborate on a response.
+
+description: |
+  When the user sends a question, answer, or information, the system infers which agent(s) to use.
+  Multiple agents may be selected to collaborate on the reply.
+
+routing:
+  allow_multiple: true   # Allow multiple agents to handle a single request
+  strategy: infer        # infer = use LLM to select agent(s) from content
+
+agents:
+  - id: paul
+    name: Paul
+    avatar: "https://res.cloudinary.com/gr3atcode/image/upload/v1771649420/Paul_ppffqv.png"
+    responsibility: Traceability Relationships
+    description: |
+      Focus on traceability: linking requirements to stakeholders and deliverables,
+      finding missing links, orphaned items, impact analysis.
+    keywords:
+      - traceability
+      - RTM
+      - relationships
+      - links
+      - impact analysis
+      - orphaned
+      - coverage
+      - traceability matrix
+
+  - id: emma
+    name: Emma
+    avatar: "https://res.cloudinary.com/gr3atcode/image/upload/v1771649419/Emma_pat3ft.png"
+    responsibility: Requirements Validation
+    description: |
+      Validates requirements: consistency, clarity, completeness; SMART criteria,
+      no conflicts, acceptance criteria; detects duplicates and gaps.
+    keywords:
+      - requirements
+      - validation
+      - SMART
+      - clarity
+      - completeness
+      - acceptance criteria
+      - conflicts
+      - requirements verification
+
+  - id: sarah
+    name: Sarah
+    avatar: "https://res.cloudinary.com/gr3atcode/image/upload/v1771649419/Sarah_fyqbgy.png"
+    responsibility: Stakeholders Mapping
+    description: |
+      Maps stakeholders: needs, interest/influence, alignment gaps
+      between requirements and stakeholder needs.
+    keywords:
+      - stakeholders
+      - mapping
+      - interest
+      - influence
+      - alignment
+      - needs
+      - stakeholder analysis
+
+  - id: david
+    name: David
+    avatar: "https://res.cloudinary.com/gr3atcode/image/upload/v1771649419/David_fy6qow.png"
+    responsibility: Compliance BABOK Check
+    description: |
+      Checks BABOK compliance and BA best practices; document structure, missing artifacts.
+    keywords:
+      - BABOK
+      - compliance
+      - best practices
+      - standards
+      - audit
+      - artifacts
+      - BA standards


### PR DESCRIPTION
Complete the Conversations API so that when a user sends a message, the backend infers which agent(s) (Paul, Emma, Sarah, David) should handle it, optionally allows multiple agents to collaborate on a single reply, and returns bot metadata. Also support GPT-style structured `content` (text + parts) and persist agent identity for list responses.