### PR TITLE
feat: implement dark mode toggle with ThemeProvider and ThemeToggle c…

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,6 @@
 import AppProvider from "@/config/app-provider";
+import { ThemeProvider } from "@/components/theme-provider";
+import { ThemeToggle } from "@/components/theme-toggle";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import './globals.css';
@@ -14,14 +16,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body>
-        <AppProvider>
-          <TooltipProvider>
-            {children}
-          </TooltipProvider>
-          <Toaster />
-        </AppProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="system"
+          enableSystem
+          disableTransitionOnChange
+        >
+          <AppProvider>
+            <TooltipProvider>
+              {children}
+              <ThemeToggle />
+            </TooltipProvider>
+            <Toaster />
+          </AppProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/components/theme-provider.tsx
+++ b/frontend/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ThemeProviderProps } from "next-themes";
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/frontend/components/theme-toggle.tsx
+++ b/frontend/components/theme-toggle.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Moon, Sun, Monitor } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export function ThemeToggle() {
+  const { setTheme, theme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="icon"
+              className="fixed bottom-4 right-4 z-50 size-9 rounded-full shadow-lg"
+            >
+              <Sun className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+              <Moon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+              <span className="sr-only">Chuyển giao diện</span>
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="left">Chuyển giao diện</TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent align="end" side="top">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="size-4" />
+          Sáng
+          {theme === "light" && (
+            <span className="ml-auto text-xs text-muted-foreground">✓</span>
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="size-4" />
+          Tối
+          {theme === "dark" && (
+            <span className="ml-auto text-xs text-muted-foreground">✓</span>
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="size-4" />
+          Hệ thống
+          {theme === "system" && (
+            <span className="ml-auto text-xs text-muted-foreground">✓</span>
+          )}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
This pull request introduces a theme switching feature to the application, allowing users to toggle between light, dark, and system themes. It does so by integrating the `next-themes` package, adding a new `ThemeProvider` component, and providing a UI toggle button accessible from all pages.

Theme support integration:

* Added a new `ThemeProvider` component (`frontend/components/theme-provider.tsx`) that wraps the app and enables theme management using the `next-themes` library.
* Updated `frontend/app/layout.tsx` to wrap the application with the new `ThemeProvider` and set up default theme behavior, including support for system theme and suppressing hydration warnings. [[1]](diffhunk://#diff-ccddbfb0d0537ee9a04df26462300003e5c30b9f0a212393cdcce2d30d2bd931R2-R3) [[2]](diffhunk://#diff-ccddbfb0d0537ee9a04df26462300003e5c30b9f0a212393cdcce2d30d2bd931L17-R34)

User interface for theme switching:

* Added a `ThemeToggle` component (`frontend/components/theme-toggle.tsx`) that provides a dropdown menu for switching between light, dark, and system themes, with appropriate icons and tooltips.
* Integrated the `ThemeToggle` button into the main layout so it is accessible from all pages.…omponents