### PR TITLE
feat: add ChatToc component for message navigation in ChatArea

### DIFF
--- a/frontend/features/conversations/components/chat-area.tsx
+++ b/frontend/features/conversations/components/chat-area.tsx
@@ -24,6 +24,7 @@ import { MessageBubble } from "./message-bubble";
 import { ChatInput } from "./chat-input";
 import { AgentPanel } from "./agent-panel";
 import { RateLimitIndicator } from "@/features/messages/components/rate-limit-indicator";
+import { ChatToc } from "./chat-toc";
 
 interface ChatAreaProps {
   projectId: number;
@@ -224,6 +225,7 @@ export function ChatArea({ projectId, conversationId }: ChatAreaProps) {
       <AgentPanel activeAgentIds={activeAgentIds} />
 
       {/* Messages area */}
+      {messages && messages.length > 0 && <ChatToc messages={messages} />}
       <ScrollArea className="flex-1 min-h-0">
         <div className="mx-auto max-w-3xl">
           {messagesLoading ? (

--- a/frontend/features/conversations/components/chat-toc.tsx
+++ b/frontend/features/conversations/components/chat-toc.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { Message } from "@/features/messages/types";
+
+/* ------------------------------------------------------------------ */
+/* Types                                                               */
+/* ------------------------------------------------------------------ */
+
+interface TocEntry {
+  id: number;
+  preview: string;
+  /** 0 = user question (top-level), 1 = assistant reply */
+  depth: number;
+}
+
+interface ChatTocProps {
+  messages: Message[];
+  className?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+/** Truncate text to maxLen chars */
+function truncate(text: string, maxLen: number): string {
+  const single = text.replace(/\s+/g, " ").trim();
+  return single.length > maxLen ? single.slice(0, maxLen) + "…" : single;
+}
+
+/** Bar widths by depth (Notion-style) */
+const BAR_WIDTH: Record<number, string> = {
+  0: "w-4", // 16px — user message
+  1: "w-3", // 12px — assistant reply
+};
+
+const BAR_INDENT: Record<number, string> = {
+  0: "ml-0",
+  1: "ml-1",
+};
+
+/* ------------------------------------------------------------------ */
+/* Component                                                           */
+/* ------------------------------------------------------------------ */
+
+export function ChatToc({ messages, className }: ChatTocProps) {
+  const [hovered, setHovered] = useState(false);
+  const [activeId, setActiveId] = useState<number | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const tocRef = useRef<HTMLDivElement>(null);
+
+  // Build TOC entries from user messages only
+  const entries: TocEntry[] = messages
+    .filter((m) => m.role === "user")
+    .map((m) => ({
+      id: m.id,
+      preview: truncate(m.content, 60),
+      depth: 0,
+    }));
+
+  // Track which message is currently in viewport
+  useEffect(() => {
+    observerRef.current?.disconnect();
+
+    const userMessageIds = entries.map((e) => e.id);
+    const elements = userMessageIds
+      .map((id) => document.getElementById(`message-${id}`))
+      .filter(Boolean) as HTMLElement[];
+
+    if (elements.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (intersections) => {
+        // Pick the first visible entry
+        for (const entry of intersections) {
+          if (entry.isIntersecting) {
+            const id = Number(entry.target.id.replace("message-", ""));
+            setActiveId(id);
+            break;
+          }
+        }
+      },
+      { threshold: 0.3 },
+    );
+
+    elements.forEach((el) => observer.observe(el));
+    observerRef.current = observer;
+
+    return () => observer.disconnect();
+  }, [entries.map((e) => e.id).join(",")]);
+
+  const scrollToMessage = useCallback((messageId: number) => {
+    const el = document.getElementById(`message-${messageId}`);
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.classList.add("bg-primary/5");
+      setTimeout(() => {
+        el.classList.remove("bg-primary/5");
+      }, 1500);
+    }
+  }, []);
+
+  if (entries.length < 2) return null;
+
+  return (
+    <div
+      ref={tocRef}
+      className={cn(
+        "fixed right-4 top-1/2 -translate-y-1/2 z-30 transition-all duration-300 ease-in-out",
+        hovered ? "w-56" : "w-7",
+        className,
+      )}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div
+        className={cn(
+          "rounded-lg transition-all duration-300",
+          hovered ? "bg-popover border shadow-lg" : "bg-transparent",
+        )}
+      >
+        {/* Collapsed: minimap bars */}
+        <div
+          className={cn(
+            "flex flex-col gap-2.5 py-3 transition-all duration-200",
+            hovered
+              ? "px-3 opacity-0 h-0 py-0 overflow-hidden"
+              : "pl-1.5 opacity-100",
+          )}
+        >
+          {entries.map((entry) => (
+            <div key={entry.id} className={BAR_INDENT[entry.depth]}>
+              <div
+                className={cn(
+                  "h-0.5 rounded-full transition-all duration-200",
+                  BAR_WIDTH[entry.depth],
+                  activeId === entry.id
+                    ? "bg-foreground shadow-[0_0_3px_var(--foreground)]"
+                    : "bg-muted-foreground/30",
+                )}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* Expanded: text list */}
+        <div
+          className={cn(
+            "transition-all duration-300 overflow-hidden",
+            hovered ? "opacity-100 max-h-80" : "opacity-0 max-h-0",
+          )}
+        >
+          <div className="px-3 pt-2.5 pb-1.5">
+            <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Câu hỏi
+            </span>
+          </div>
+          <ScrollArea className="max-h-64">
+            <div className="flex flex-col gap-0.5 px-1.5 pb-2">
+              {entries.map((entry, idx) => (
+                <button
+                  key={entry.id}
+                  type="button"
+                  onClick={() => scrollToMessage(entry.id)}
+                  className={cn(
+                    "flex items-start gap-2 text-left rounded-md px-2 py-1.5 text-xs transition-colors cursor-pointer",
+                    "hover:bg-muted",
+                    activeId === entry.id
+                      ? "text-foreground font-medium bg-muted/60"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  <span className="shrink-0 text-[10px] tabular-nums text-muted-foreground/60 mt-px w-3 text-right">
+                    {idx + 1}
+                  </span>
+                  <span className="line-clamp-2 leading-snug">
+                    {entry.preview}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </ScrollArea>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/features/conversations/components/index.ts
+++ b/frontend/features/conversations/components/index.ts
@@ -6,3 +6,4 @@ export { ChatArea } from "./chat-area";
 export { ChatInput } from "./chat-input";
 export { MessageBubble } from "./message-bubble";
 export { AgentPanel } from "./agent-panel";
+export { ChatToc } from "./chat-toc";


### PR DESCRIPTION
This pull request adds a new "table of contents" (TOC) feature for chat conversations, making it easier for users to navigate between questions in a conversation. The TOC appears as a minimap sidebar that expands to show a list of user questions, allowing quick scrolling to each message. The main changes involve integrating this new `ChatToc` component into the chat area and exporting it for use elsewhere.

**Chat TOC feature integration:**

* Added the new `ChatToc` component, which displays a minimap and expandable list of user messages, allows navigation by clicking, and visually highlights the currently viewed question. (`frontend/features/conversations/components/chat-toc.tsx`)
* Integrated `ChatToc` into the `ChatArea` component so it appears when there are messages in a conversation. (`frontend/features/conversations/components/chat-area.tsx`) [[1]](diffhunk://#diff-755b58419ab8f63d2a0bc5e269dd6e22c5eb19de29d1cea2777e7d4ce2e3ed91R27) [[2]](diffhunk://#diff-755b58419ab8f63d2a0bc5e269dd6e22c5eb19de29d1cea2777e7d4ce2e3ed91R228)
* Exported `ChatToc` from the components index for easier reuse. (`frontend/features/conversations/components/index.ts`)