### PR TITLE
feat: handle structured (meta) message content and improve agent routing

### DIFF
--- a/backend/app/services/agent_router.py
+++ b/backend/app/services/agent_router.py
@@ -1,6 +1,10 @@
 """
 Router: infers which agent(s) should handle the user's question or input.
 Reads conversation-agents.yaml and uses the LLM to select one or more agents.
+
+Includes intelligent requirement analyzer: before routing, user input is
+analyzed and refactored (GIVEN DATA, USER GOAL, IMPLICIT ASSUMPTIONS,
+MISSING INFORMATION) so Gemini receives a clear, structured requirement.
 """
 import json
 import re
@@ -14,6 +18,125 @@ CONVERSATION_AGENTS_CONFIG = (
 )
 
 _agents_config_cache = None
+
+# --- Intelligent requirement analyzer ---
+
+REQUIREMENT_ANALYSIS_KEYS = (
+    "given_data",
+    "user_goal",
+    "implicit_assumptions",
+    "missing_information",
+    "refactored_requirement",
+)
+
+
+def _build_requirement_analyzer_prompt(user_message: str) -> str:
+    """Build prompt for analyzing and refactoring user requirement."""
+    return """You are a requirement analyzer. Analyze the user message and output exactly one JSON object. Do not assign to any agent.
+
+Rules:
+- Extract only what is explicitly stated; do not assume or hallucinate.
+- If the goal is unclear, say so in user_goal.
+- Output valid JSON only; no markdown, no extra text.
+
+JSON keys:
+- given_data: array of strings — explicit facts, numbers, constraints stated by the user.
+- user_goal: string — what the user wants. If unclear: "Unclear" and brief reason.
+- implicit_assumptions: array of strings — inferences from context. Use [] if none.
+- missing_information: array of strings — critical info not provided. Use [] if none.
+- refactored_requirement: string — one clear paragraph restating the requirement for an LLM. Use the same language as the user; preserve all explicit facts; do not add assumptions.
+
+Example shape:
+{"given_data": [], "user_goal": "", "implicit_assumptions": [], "missing_information": [], "refactored_requirement": ""}
+
+User message:
+
+""" + (user_message[:8000] if user_message else "(empty)")
+
+
+def analyze_and_refactor_requirement(user_message: str) -> tuple[dict, str]:
+    """
+    Analyze user requirement into GIVEN DATA, USER GOAL, IMPLICIT ASSUMPTIONS, MISSING INFORMATION,
+    and produce a refactored requirement string for Gemini.
+    Returns (analysis_dict, refactored_requirement_str).
+    On failure, returns ({}, user_message) so callers can fall back to original.
+    """
+    if not (user_message or "").strip():
+        return {}, user_message or ""
+
+    prompt = _build_requirement_analyzer_prompt(user_message)
+    try:
+        text = generate_text(prompt).strip()
+    except Exception:
+        return {}, user_message
+
+    # Extract JSON object (allow markdown code block or raw JSON)
+    json_match = re.search(r"\{[\s\S]*\}", text)
+    if not json_match:
+        return {}, user_message
+
+    try:
+        data = json.loads(json_match.group())
+    except json.JSONDecodeError:
+        return {}, user_message
+
+    if not isinstance(data, dict):
+        return {}, user_message
+
+    refactored = (data.get("refactored_requirement") or "").strip()
+    if not refactored:
+        refactored = user_message
+
+    analysis = {k: data.get(k) for k in REQUIREMENT_ANALYSIS_KEYS if k in data}
+    return analysis, refactored
+
+
+def refactor_requirement_for_gemini(user_message: str) -> str:
+    """
+    Refactor the user's input requirement so Gemini understands it correctly.
+    Runs the intelligent requirement analyzer; returns the refactored requirement string.
+    On analyzer failure, returns the original user_message.
+    """
+    _, refactored = analyze_and_refactor_requirement(user_message)
+    return refactored if refactored else user_message
+
+
+# --- Agent routing ---
+
+# Message shown when the request is out of scope and we assign Alex
+OUT_OF_SCOPE_ALEX_MESSAGE = (
+    "This request is outside the scope of the specialized agents. "
+    "The system has assigned Alex to help you."
+)
+
+
+def _agent_mention_patterns(agents: list[dict]) -> list[tuple[str, str]]:
+    """Return [(pattern, agent_id), ...] for whole-word mention of agent name or id."""
+    result = []
+    for a in agents:
+        aid = a.get("id") or ""
+        name = (a.get("name") or "").strip()
+        if aid:
+            result.append((rf"(?:\b{re.escape(aid)}\b)", aid))
+        if name and name != aid:
+            result.append((rf"(?:\b{re.escape(name)}\b)", aid))
+    return result
+
+
+def _detect_mentioned_agent(user_message: str, agents: list[dict]) -> list[str] | None:
+    """
+    If the user explicitly mentions an agent by name or id (e.g. 'Emma', 'ask Emma', 'emma'),
+    return that agent's id(s) so we route to them. Otherwise return None.
+    """
+    if not (user_message or "").strip() or not agents:
+        return None
+    mentioned_ids = []
+    seen = set()
+    for pattern, agent_id in _agent_mention_patterns(agents):
+        if re.search(pattern, user_message, re.IGNORECASE) and agent_id not in seen:
+            mentioned_ids.append(agent_id)
+            seen.add(agent_id)
+    return mentioned_ids if mentioned_ids else None
 
 
 def load_agents_config() -> list[dict]:
@@ -33,47 +156,82 @@ def load_agents_config() -> list[dict]:
 
 def _build_router_prompt(agents: list[dict], user_message: str) -> str:
     """Build prompt for LLM to select which agent(s) handle the message."""
-    lines = [
-        "You are a router. Given the following agents and the user message, choose which agent(s) should handle this request.",
-        "Reply with ONLY a JSON array of agent ids, e.g. [\"emma\"] or [\"emma\", \"sarah\"]. No other text.",
-        "",
-        "Agents:",
-    ]
-    for a in agents:
-        lines.append(f"  - id: {a.get('id', '')}")
-        lines.append(f"    responsibility: {a.get('responsibility', '')}")
-        lines.append(f"    description: {a.get('description', '').strip()[:200]}")
-        lines.append("")
-    lines.append("User message:")
-    lines.append(user_message[:2000])
-    lines.append("")
-    lines.append("Reply with JSON array of ids only:")
-    return "\n".join(lines)
+    agent_list = "\n".join(
+        f"- id: {a.get('id', '')} | {a.get('name', '')} — {a.get('responsibility', '')}. {a.get('description', '').strip()[:180]}"
+        for a in agents
+    )
+    specialist_ids = [a.get("id") for a in agents if (a.get("id") or "").lower() != "alex"]
+    specialist_list = ", ".join(specialist_ids) if specialist_ids else "none"
+
+    return f"""You are a router. Choose which agent(s) should handle this request.
+
+Agents (id | name — responsibility. description):
+{agent_list}
+
+User message:
+{user_message[:2000]}
+
+Rules:
+- Reply with ONLY one JSON object: {{"agent_ids": ["id1", "id2"], "out_of_scope": false}}.
+- agent_ids: array of agent ids that best match the request (e.g. ["emma"] or ["emma", "sarah"]).
+- out_of_scope: set to true only when the request does NOT fit any specialist ({specialist_list}). In that case reply with {{"agent_ids": ["alex"], "out_of_scope": true}} so the user is told Alex was assigned.
+- Prefer one agent when one clearly fits; use multiple only when the request spans responsibilities.
+- Valid ids: {", ".join(a.get("id", "") for a in agents)}.
+
+Reply (JSON only):"""
 
 
-def route_to_agents(user_message: str) -> list[str]:
+def route_to_agents(user_message: str) -> tuple[list[str], bool]:
     """
     Infer which agent(s) should handle the user message.
-    Returns list of agent ids (e.g. ["emma", "sarah"]). Uses config conversation-agents.yaml.
+    If the user mentions an agent by name or id (e.g. "Emma", "ask Emma"), that agent is selected.
+    Returns (agent_ids, out_of_scope) where out_of_scope is True when the request was assigned to Alex
+    because it did not fit any specialist (so the caller can tell the user).
     """
     agents = load_agents_config()
     if not agents:
-        return ["alex"]
+        return ["alex"], True
+
+    # If user explicitly mentions an agent name/id, route to that agent
+    mentioned = _detect_mentioned_agent(user_message or "", agents)
+    if mentioned:
+        return mentioned, False
+
     prompt = _build_router_prompt(agents, user_message or "")
-    text = generate_text(prompt).strip()
-    # Parse JSON array from response (allow trailing text)
-    match = re.search(r"\[[\s\S]*?\]", text)
-    if not match:
-        return [agents[0]["id"]]
     try:
-        ids = json.loads(match.group())
-        if not isinstance(ids, list):
-            return [agents[0]["id"]]
-        valid_ids = {a["id"] for a in agents}
-        selected = [x for x in ids if isinstance(x, str) and x in valid_ids]
-        return selected if selected else [agents[0]["id"]]
-    except (json.JSONDecodeError, TypeError):
-        return [agents[0]["id"]]
+        text = generate_text(prompt).strip()
+    except Exception:
+        return [agents[0]["id"]], False
+
+    valid_ids = {a["id"] for a in agents}
+    # Prefer new format: {"agent_ids": [...], "out_of_scope": bool}
+    obj_match = re.search(r"\{[\s\S]*\}", text)
+    if obj_match:
+        try:
+            data = json.loads(obj_match.group())
+            if isinstance(data, dict):
+                ids = data.get("agent_ids")
+                out_of_scope = data.get("out_of_scope") is True
+                if isinstance(ids, list):
+                    selected = [x for x in ids if isinstance(x, str) and x in valid_ids]
+                    if selected:
+                        return selected, out_of_scope
+        except json.JSONDecodeError:
+            pass
+
+    # Fallback: try legacy array format [id1, id2]
+    match = re.search(r"\[[\s\S]*?\]", text)
+    if match:
+        try:
+            ids = json.loads(match.group())
+            if isinstance(ids, list):
+                selected = [x for x in ids if isinstance(x, str) and x in valid_ids]
+                if selected:
+                    return selected, selected == ["alex"]
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    return [agents[0]["id"]], False
 
 
 def get_agent_info_from_config(agent_id: str) -> dict | None:

--- a/backend/app/services/content_normalizer.py
+++ b/backend/app/services/content_normalizer.py
@@ -10,7 +10,7 @@ drop empty ones, and join with double newline so the prompt has clear structure 
 """
 
 # Maximum number of parts to avoid abuse
-MAX_PARTS = 50
+MAX_PARTS = 1_000
 # Maximum total length after normalization (chars)
 MAX_NORMALIZED_LENGTH = 50_000
 

--- a/backend/app/services/conversation_agent.py
+++ b/backend/app/services/conversation_agent.py
@@ -6,6 +6,8 @@ from app.models import Message
 from app.services.agent_router import (
     get_agent_info_from_config,
     load_agents_config,
+    OUT_OF_SCOPE_ALEX_MESSAGE,
+    refactor_requirement_for_gemini,
     route_to_agents,
 )
 from app.services.gemini_client import generate_chat
@@ -97,9 +99,13 @@ def get_conversation_bot(primary_agent_id: str | None = None) -> dict:
 def get_agent_reply(conversation_id: int, new_user_content: str) -> tuple[str, list[str]]:
     """
     Infer which agent(s) to use, build combined prompt when multiple agents, then reply.
+    First runs intelligent requirement analyzer to refactor user input; routing and
+    reply use the refactored requirement so Gemini understands correctly.
     Returns (reply_text, selected_agent_ids). Caller may use selected_agent_ids[0] for bot.
+    When the request is out of scope, reply_text is prefixed with OUT_OF_SCOPE_ALEX_MESSAGE.
     """
-    selected_ids = route_to_agents(new_user_content)
+    refactored_content = refactor_requirement_for_gemini(new_user_content)
+    selected_ids, out_of_scope = route_to_agents(refactored_content)
     agents_config = load_agents_config()
     selected_agents = [a for a in agents_config if a.get("id") in selected_ids]
     if selected_agents:
@@ -117,5 +123,7 @@ def get_agent_reply(conversation_id: int, new_user_content: str) -> tuple[str, l
         for m in messages
         if m.role in ("user", "assistant")
     ]
-    reply_text = generate_chat(system_prompt, history, new_user_content)
+    reply_text = generate_chat(system_prompt, history, refactored_content)
+    if out_of_scope:
+        reply_text = f"{OUT_OF_SCOPE_ALEX_MESSAGE}\n\n{reply_text}"
     return reply_text, selected_ids

--- a/backend/app/services/document_parser.py
+++ b/backend/app/services/document_parser.py
@@ -3,8 +3,8 @@ import math
 from pathlib import Path
 
 ALLOWED_EXTENSIONS = {".pdf", ".docx", ".doc", ".txt", ".xlsx", ".xls"}
-MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024  # 5 MB
-MAX_PAGE_COUNT = 10
+MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024  # 50 MB
+MAX_PAGE_COUNT = 300
 
 
 def parse_document(file_path: str) -> dict:

--- a/docs/DOCUMENT-UPLOAD-FLOW.md
+++ b/docs/DOCUMENT-UPLOAD-FLOW.md
@@ -49,8 +49,8 @@ Khi người dùng **gửi message kèm tài liệu**, hệ thống sẽ:
 | Quy tắc                    | Giá trị                                          |
 | -------------------------- | ------------------------------------------------ |
 | Định dạng chấp nhận        | `.pdf`, `.docx`, `.doc`, `.txt`, `.xlsx`, `.xls` |
-| Kích thước tối đa          | **5 MB**                                         |
-| Số trang tối đa            | **10 trang**                                     |
+| Kích thước tối đa          | **100 MB**                                         |
+| Số trang tối đa            | **300 trang**                                     |
 | Cách tính trang — PDF      | Đếm thực tế (`len(reader.pages)`)                |
 | Cách tính trang — DOCX/DOC | Ước lượng: `ceil(word_count / 300)`              |
 | Cách tính trang — TXT      | Ước lượng: `ceil(char_count / 1800)`             |
@@ -181,7 +181,7 @@ Form gồm 3 trường:
 Validation client-side (cùng logic với chat-input):
 
 - `ACCEPTED_EXTS = Set(["pdf","docx","doc","txt","xlsx","xls"])`
-- `MAX_FILE_SIZE = 5 * 1024 * 1024` (5MB)
+- `MAX_FILE_SIZE = 100 * 1024 * 1024` (5MB)
 
 ---
 
@@ -217,8 +217,8 @@ export interface Document {
 
 ```python
 ALLOWED_EXTENSIONS = {".pdf", ".docx", ".doc", ".txt", ".xlsx", ".xls"}
-MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024   # 5 MB
-MAX_PAGE_COUNT = 10
+MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024   # 100 MB
+MAX_PAGE_COUNT = 300
 ```
 
 Hàm chính: `parse_document(file_path) → { document_text, document_metadata }`

--- a/frontend/app/projects/page.tsx
+++ b/frontend/app/projects/page.tsx
@@ -2,14 +2,26 @@ import { ProjectList } from "@/features/projects/components";
 
 export default function ProjectsPage() {
   return (
-    <div className="container mx-auto max-w-5xl py-8 px-4">
-      <div className="mb-6">
-        <h1 className="text-3xl font-bold tracking-tight">Dự án</h1>
-        <p className="text-muted-foreground mt-1">
-          Tạo và quản lý các dự án phân tích nghiệp vụ.
-        </p>
+    <>
+      <div className="container mx-auto max-w-5xl py-8 px-4 pb-16">
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold tracking-tight">Dự án</h1>
+          <p className="text-muted-foreground mt-1">
+            Tạo và quản lý các dự án phân tích nghiệp vụ.
+          </p>
+        </div>
+        <ProjectList />
       </div>
-      <ProjectList />
-    </div>
+      <footer className="fixed bottom-0 left-0 right-0 py-4 border-t border-border bg-background text-center">
+        <a
+          href="https://businessanalysis.io/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-muted-foreground hover:text-foreground transition-colors text-sm"
+        >
+          Made with ❤ by BAWS Team
+        </a>
+      </footer>
+    </>
   );
 }

--- a/frontend/features/messages/api.ts
+++ b/frontend/features/messages/api.ts
@@ -63,9 +63,9 @@ export async function sendMessageApi(
     if (response.status === 500) {
       throw new Error("Agent xử lý thất bại. Vui lòng thử lại.");
     }
-    throw new Error("Không thể gửi tin nhắn");
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.error || "Không thể gửi tin nhắn");
   }
-
   return response.json();
 }
 


### PR DESCRIPTION
- Structured message content: The send-message API now accepts both plain text and a structured payload (content_type + parts) for user messages. The backend normalizes this into a single string for storage and for the conversation agent, so the frontend can send logical segments (e.g. paragraphs, bullets) without changing DB or prompt behavior.
- Router and conversation behavior: Agent routing and conversation handling are updated (requirement analysis, agent-name detection, out-of-scope → Alex, and no “Hi” on follow-up replies). Documentation for the document upload/RAG flow is updated.