### PR TITLE
refactor: move document context from conversation scope to project scope

### DIFF
--- a/backend/app/services/conversation_agent.py
+++ b/backend/app/services/conversation_agent.py
@@ -1,8 +1,9 @@
 """Conversation agent: BA chat with history; router selects agent(s), multiple agents may collaborate."""
+import logging
 from pathlib import Path
 
 from app.agents.base import get_agent_bot_info
-from app.models import Message
+from app.models import Message, Conversation
 from app.services.agent_router import (
     get_agent_info_from_config,
     load_agents_config,
@@ -11,6 +12,8 @@ from app.services.agent_router import (
     route_to_agents,
 )
 from app.services.gemini_client import generate_chat
+
+logger = logging.getLogger(__name__)
 
 # Fallback when config has no agents or router returns none
 CONVERSATION_AGENT_ID = "alex"
@@ -112,6 +115,20 @@ def get_agent_reply(conversation_id: int, new_user_content: str) -> tuple[str, l
         system_prompt = _build_multi_agent_system_prompt(selected_agents)
     else:
         system_prompt = get_conversation_system_prompt()
+
+    # ── Inject project-wide document context (RAG summaries) ─────────────
+    # All RAG-processed documents in the project are available to every
+    # conversation, so the agent has knowledge of uploaded materials
+    # without needing the user to re-attach them each time.
+    try:
+        conv = Conversation.query.get(conversation_id)
+        if conv:
+            from app.services.document_rag import build_project_documents_context
+            doc_context = build_project_documents_context(conv.project_id)
+            if doc_context:
+                system_prompt = f"{system_prompt}\n\n{doc_context}"
+    except Exception as exc:
+        logger.warning("Failed to inject project docs context: %s", exc)
 
     messages = (
         Message.query.filter_by(conversation_id=conversation_id)

--- a/backend/app/services/document_rag.py
+++ b/backend/app/services/document_rag.py
@@ -179,3 +179,51 @@ def build_document_context_block(document) -> str:
         lines.append(f"User notes (for reference only): {document.notes}")
 
     return "\n".join(lines)
+
+
+def build_project_documents_context(project_id: int) -> str | None:
+    """
+    Build a compact context block from ALL RAG-processed documents in the project.
+    Uses pre-computed summaries/keywords/points so no extra Gemini calls are needed.
+    Returns None if no documents are available.
+    """
+    from app.models.document import Document
+
+    docs = (
+        Document.query
+        .filter_by(project_id=project_id)
+        .filter(Document.rag_processed_at.isnot(None))
+        .order_by(Document.created_at.asc())
+        .all()
+    )
+    if not docs:
+        return None
+
+    blocks = []
+    for doc in docs:
+        block_lines = [f"📄 {doc.filename}"]
+        if doc.summary:
+            block_lines.append(f"   Summary: {doc.summary}")
+        try:
+            kw = json.loads(doc.keywords) if doc.keywords else []
+        except Exception:
+            kw = []
+        if kw:
+            block_lines.append(f"   Keywords: {', '.join(kw)}")
+        try:
+            pts = json.loads(doc.important_points) if doc.important_points else []
+        except Exception:
+            pts = []
+        if pts:
+            for p in pts:
+                block_lines.append(f"   • {p}")
+        if doc.assigned_agent:
+            block_lines.append(f"   Agent: {doc.assigned_agent}")
+        blocks.append("\n".join(block_lines))
+
+    header = (
+        f"[PROJECT DOCUMENTS — {len(docs)} file(s)]\n"
+        "The following documents have been uploaded to this project. "
+        "Use this knowledge to answer user questions across all conversations in the project.\n"
+    )
+    return header + "\n\n".join(blocks)


### PR DESCRIPTION
This pull request enhances the conversation agent by injecting project-wide document context into every chat, allowing agents to leverage all RAG-processed documents for improved responses. It introduces a new utility to build a compact summary of project documents and ensures this context is automatically included for all conversations.

**Project-wide document context injection:**

* The `get_agent_reply` function in `conversation_agent.py` now automatically appends a summary of all RAG-processed documents in the project to the system prompt for every conversation. This enables agents to answer user questions using the full set of uploaded materials, without requiring users to re-attach documents.

* Added robust error handling and logging for the document context injection process, so failures are logged but do not interrupt the conversation flow.

**New utility for summarizing project documents:**

* Introduced `build_project_documents_context` in `document_rag.py`, which compiles summaries, keywords, important points, and assigned agents for all RAG-processed documents in a project into a compact context block, using only pre-computed data (no extra Gemini calls).

**General improvements:**

* Updated imports in `conversation_agent.py` to include `Conversation`, supporting the new context injection logic.